### PR TITLE
SidebarContext for panel shifting when the sidebar opens

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,0 +1,7 @@
+1. Filter panel should move to the right when the sidebar opens. 
+
+2. When you insert the more filters it doesnt seem to work properly. It only cares about city and type 
+
+3. I should put more plots in for each type, so it shows more diverse data points 
+
+4. should i move all my hooks into a file for themselves so that i have them all together in a single file or in a folder with a file for each hook?

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,14 +3,18 @@
 import MapView from "../components/MapView/MapView";
 import FilterPanel from "../components/FilterPanel/FilterPanel";
 import styles from "../styles/Home.module.scss";
+import { SidebarProvider } from "../context/SidebarContext";
 
 export default function Page() {
+  
   return (
-    <div className={styles.pageWrapper}>
-      <FilterPanel />
-      <div className={styles.mapContainer}>
-        <MapView />
+    <SidebarProvider>
+      <div className={styles.pageWrapper}>
+        <FilterPanel />
+        <div className={styles.mapContainer}>
+          <MapView />
+        </div>
       </div>
-    </div>
+    </SidebarProvider>
   );
 }

--- a/src/components/FilterPanel/FilterPanel.tsx
+++ b/src/components/FilterPanel/FilterPanel.tsx
@@ -3,14 +3,16 @@
 import React from "react";
 import { useFilters } from "../../context/FilterContext";
 import styles from "../../styles/Home.module.scss";
+import { useSidebar } from "../../context/SidebarContext";
 
 // This function renders the filter panel with dropdowns for our filters
 export default function FilterPanel() {
+  const { sidebarOpen } = useSidebar();
   const { filters, setFilters } = useFilters();
   const [showMore, setShowMore] = React.useState(false); // State to toggle additional filters
 
   return (
-    <div className={styles.filterPanel}>
+    <div className={`${styles.filterPanel} ${sidebarOpen ? styles.filterPanelShifted : ""}`}> {/* We add a class to shift the filter panel when the sidebar is open */}
       <label>
         City:
         <select

--- a/src/components/MapView/MapView.tsx
+++ b/src/components/MapView/MapView.tsx
@@ -13,7 +13,7 @@ import { useFilters } from "../../context/FilterContext";
 import type { Incident } from "../../types/incident";
 import styles from "../../styles/Home.module.scss";
 import { http } from "../../api/http";
-
+import { useSidebar } from "../../context/SidebarContext";
 
 // Initial view state for the map
 const INITIAL_VIEW_STATE = {
@@ -25,9 +25,14 @@ const INITIAL_VIEW_STATE = {
 };
 
 
+
+
 // Main MapView component. Here we integrate the map with filtering functionality.
 export default function MapView() {
-  const { filters } = useFilters();
+
+  const { sidebarOpen, setSidebarOpen } = useSidebar(); // Get sidebar state to to shift the filter panel to the right when opening the sidebar
+
+  const { filters } = useFilters(); // Get current filters from context
 
 // Declaration of the useState hook to render information about the plot(incidents) when hovered over with the mouse
 const [hoverInfo, setHoverInfo] = React.useState<{ 
@@ -77,6 +82,7 @@ const [selectedIncident, setSelectedIncident] = useState<Incident | null>(null);
       onClick: (info) => {
         if (info.object) {
           setSelectedIncident(info.object); // Open Sidebar with incident details
+          setSidebarOpen(true); // Open the sidebar when an incident is clicked
         }
       }
     }),
@@ -85,9 +91,11 @@ const [selectedIncident, setSelectedIncident] = useState<Incident | null>(null);
   // The getCursor prop changes the cursor to a pointer when hovering over an incident, and to a grab hand when panning the map
   return (
   <>
+  <div className={sidebarOpen ? styles.mapShifted : styles.mapView}> {/* We shift the map view when the sidebar is open */}
     <DeckGL initialViewState={INITIAL_VIEW_STATE} controller layers={layers} getCursor={({ isHovering }) => (isHovering ? 'pointer' : 'grab')}>
       <Map mapStyle="https://api.maptiler.com/maps/streets/style.json?key=NOe6RNQlyuLRNVci1Jv1" />
     </DeckGL>
+    </div>
     {hoverInfo && hoverInfo.object && (
       <div className={styles.hoverTooltip} style={{ // This is for displaying a dialogue box when hovering over an incident
         position: 'absolute', // Ensure the tooltip is positioned absolutely
@@ -107,7 +115,10 @@ const [selectedIncident, setSelectedIncident] = useState<Incident | null>(null);
   <div className={styles.sidebar}>
     <button
       className={styles.closeButton}
-      onClick={() => setSelectedIncident(null)}
+      onClick={() => {
+        setSelectedIncident(null);
+        setSidebarOpen(false); // This resets the filter panel position when closing the sidebar
+      }}
     >
       ✕
     </button>

--- a/src/context/SidebarContext.tsx
+++ b/src/context/SidebarContext.tsx
@@ -1,0 +1,23 @@
+import React, { createContext, useContext, useState } from "react";
+
+type SidebarContextType = {
+  sidebarOpen: boolean;
+  setSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
+const SidebarContext = createContext<SidebarContextType | undefined>(undefined);
+
+export const SidebarProvider = ({ children }: { children: React.ReactNode }) => {
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  return (
+    <SidebarContext.Provider value={{ sidebarOpen, setSidebarOpen }}>
+      {children}
+    </SidebarContext.Provider>
+  );
+};
+
+export const useSidebar = () => {
+  const context = useContext(SidebarContext);
+  if (!context) throw new Error("useSidebar must be used within a SidebarProvider");
+  return context;
+};

--- a/src/styles/Home.module.scss
+++ b/src/styles/Home.module.scss
@@ -1,6 +1,6 @@
 .filterPanel {
   position: absolute;      // float above the map
-  top: 15px;               // inset from top
+  top: 15px;               // insert from top
   left: 13px;              // inset from left
   display: flex;
   gap: 0.5rem;
@@ -9,6 +9,7 @@
   border-radius: 8px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
   z-index: 5;
+  transition: 0.3s ease; // Smooth transition for position changes (e.g., when sidebar opens and closes)
 
   select {
     padding: 0.35rem 0.5rem;
@@ -33,9 +34,12 @@
 }
 
 .pageWrapper {
+  position: relative;
   display: flex;
   flex-direction: column;
   height: 100vh;
+  width: 100vw;
+  flex-direction: column;
 }
 
 .mapContainer {
@@ -61,7 +65,7 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: 22%; // Slightly larger for clarity
+  width: 20%; 
   height: 100%;
   background: #fafafa;
   border-right: 1px solid #ddd;
@@ -104,4 +108,16 @@
   &:hover {
     color: #000;
   }
+}
+
+.filterPanelShifted {
+  left: 22.5%; // Shift right when sidebar is open (same as sidebar width)
+  transition: left 0.3s ease; // Smooth transition when shifting
+  position: absolute;
+}
+
+// .mapShifted is used to visually shift the map left when the sidebar is open, keeping the map fully visible and not overlapped by the sidebar.
+.mapShifted {
+  margin-right: 22%;
+  transition: margin-right 0.3s ease; // Smooth transition when shifting
 }

--- a/src/types/incident.ts
+++ b/src/types/incident.ts
@@ -12,3 +12,4 @@ export type Incident = {
   source: string;
   description: string;
 };
+


### PR DESCRIPTION
I created a new SidebarContext file to move filterpanel when the sidebar opens. I used context to avoid prop drilling and makes the sidebar state avaliable anywhere in my component tree. Now I can just use "useSidebar()" in any component to acess or update the sidebar state.

Alot of small rough patches with the scss not working properly, and then I found out I was missing a "n" in the FilterPanel name yay